### PR TITLE
Keep directories which contain only *.proto files and subdirectories

### DIFF
--- a/clean.go
+++ b/clean.go
@@ -11,11 +11,7 @@ import (
 	"github.com/LK4D4/vndr/godl"
 )
 
-func isCDir(path string) bool {
-	fis, err := ioutil.ReadDir(path)
-	if err != nil {
-		return false
-	}
+func isCDir(fis []os.FileInfo) bool {
 	var hFound bool
 	for _, fi := range fis {
 		ext := filepath.Ext(fi.Name())
@@ -27,6 +23,29 @@ func isCDir(path string) bool {
 		}
 	}
 	return hFound
+}
+
+func isPBDir(fis []os.FileInfo) bool {
+	var pbFound bool
+	for _, fi := range fis {
+		if fi.IsDir() {
+			continue
+		}
+		ext := filepath.Ext(fi.Name())
+		if ext != ".proto" {
+			return false
+		}
+		pbFound = true
+	}
+	return pbFound
+}
+
+func isInterestingDir(path string) bool {
+	fis, err := ioutil.ReadDir(path)
+	if err != nil {
+		return false
+	}
+	return isCDir(fis) || isPBDir(fis)
 }
 
 func isGoFile(path string) bool {
@@ -62,7 +81,7 @@ func cleanVendor(vendorDir string, realDeps []*build.Package) error {
 			if i.Name() == "testdata" {
 				return os.RemoveAll(path)
 			}
-			if isCDir(path) {
+			if isInterestingDir(path) {
 				realPaths[path] = true
 				return nil
 			}


### PR DESCRIPTION
These can be referenced by *.proto files kept via b1f824fe5960, which only kept
*.proto located in directories on which something also has a go dependency.

The approach here keeps only *.proto files which are alone in a directory
(apart from other subdirectories), this retains protobuf include dirs without
pulling in lots of other stuff, but assumes that e.g. a foo.proto in a
directory with foo.go is only wanted if foo.go is.

The example I tripped over was vendoring github.com/gogo/protobuf where
github.com/gogo/protobuf/gogoproto/gogo.proto imports
google/protobuf/descriptor.proto but
github.com/gogo/protobuf/protobuf/google/protobuf/descriptor.proto is cleaned
away (as would github.com/google/protobuf's version)

Signed-off-by: Ian Campbell <ian.campbell@docker.com>