### PR TITLE
Fix vendoring issue at the root of gopath

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -163,7 +163,12 @@ func hasSubdir(root, dir string) (rel string, ok bool) {
 	if !strings.HasSuffix(root, sep) {
 		root += sep
 	}
+
 	dir = filepath.Clean(dir)
+	if !strings.HasSuffix(dir, sep) {
+		dir += sep
+	}
+
 	if !strings.HasPrefix(dir, root) {
 		return "", false
 	}


### PR DESCRIPTION
When the source is organized in such a way that the vendoring happens at
$GOPATH/src directory, the check to find dependencies in the vendor
directory fails to find the deps because of the check looking for `src/`
while the trailing `/` will be missing. Added the trailing seperator for
this to work.

Signed-off-by: Jana Radhakrishnan <mrjana@gmail.com>