### PR TITLE
Normalize repo downloading

### DIFF
--- a/clean.go
+++ b/clean.go
@@ -136,6 +136,9 @@ func cleanVCS(v *godl.VCS) error {
 		return err
 	}
 	return filepath.Walk(v.Root, func(path string, i os.FileInfo, err error) error {
+		if i == nil { // this means we lost the file/dir sometime during the WalkFunc invocation
+			return filepath.SkipDir
+		}
 		if path == vendorDir {
 			return nil
 		}

--- a/clone.go
+++ b/clone.go
@@ -61,16 +61,35 @@ func parseDeps(r io.Reader) ([]depEntry, error) {
 }
 
 func cloneAll(vd string, ds []depEntry) error {
+	seen := map[string]struct{}{}
+	seenMutex := new(sync.Mutex)
+
 	var wg sync.WaitGroup
 	errCh := make(chan error, len(ds))
 	limit := make(chan struct{}, 16)
 	for _, d := range ds {
 		wg.Add(1)
 		go func(d depEntry) {
-			limit <- struct{}{}
-			errCh <- cloneDep(vd, d)
+			// placed deliberately outside the mutex to improve performance
+			root, err := godl.RepoRoot(d.importPath)
+			if err == nil {
+				seenMutex.Lock()
+				if _, ok := seen[root]; ok {
+					seenMutex.Unlock()
+					wg.Done()
+					return
+				}
+				seen[root] = struct{}{}
+				seenMutex.Unlock()
+
+				limit <- struct{}{}
+				errCh <- cloneDep(vd, d)
+				<-limit
+			} else {
+				errCh <- err
+				limit <- struct{}{}
+			}
 			wg.Done()
-			<-limit
 		}(d)
 	}
 	wg.Wait()

--- a/godl/vcs.go
+++ b/godl/vcs.go
@@ -19,6 +19,12 @@ import (
 	"github.com/LK4D4/vndr/godl/singleflight"
 )
 
+// RepoRoot gets the root of a given repository, if it exists.
+func RepoRoot(importPath string) (string, error) {
+	root, err := repoRootForImportPath(importPath, secure)
+	return root.repo, err
+}
+
 // envForDir returns a copy of the environment
 // suitable for running in the given directory.
 // The environment is the current process's environment


### PR DESCRIPTION
There are also a few other small changes.

Basically this exposes your repo-root-finding functionality and applies it to a
map/reduce which only runs clone operations a subset of the repositories listed
in the vendor.conf; these repositories are simply the roots of all of them.

Fixes #14
