### PR TITLE
Fix path handling on windows.

### DIFF
--- a/main.go
+++ b/main.go
@@ -139,6 +139,12 @@ func main() {
 	if err != nil {
 		log.Fatalf("Error getting working directory: %v", err)
 	}
+
+	wd, err = filepath.EvalSymlinks(wd)
+	if err != nil {
+		log.Fatalf("Error getting working directory after evalsymlinks: %v", err)
+	}
+
 	log.Println("Collecting initial packages")
 	initPkgs, err := collectPkgs(wd)
 	if err != nil {


### PR DESCRIPTION
os.Getwd() can return volume letter in different casings depending on the moon phase. It can be C:\ or it can be c:\. Which, in turn, ruins any checks after that, because GOPATH and other stuff is most likely C:\.

This is actually a quickfix commit - the proper fix should lowercase or uppercase EVERYTHING on Windows (because Windows paths are not case-sensitive) but it would require a lot of overhauling and will introduce additional performance penalty for Windows users. Think about it in the future.