### PR TITLE
clean: add -test flag to preserve vendor/ tests

### DIFF
--- a/clean.go
+++ b/clean.go
@@ -71,6 +71,17 @@ func cleanVendor(vendorDir string, realDeps []*build.Package) error {
 		if err != nil {
 			return nil
 		}
+
+		// When preserving tests don't delete testdata, let alone _test.go files.
+		if preserveTest {
+			if i.Name() == "testdata" {
+				return nil
+			}
+			if strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+		}
+
 		if strings.HasPrefix(i.Name(), ".") || strings.HasPrefix(i.Name(), "_") {
 			return os.RemoveAll(path)
 		}

--- a/main.go
+++ b/main.go
@@ -22,7 +22,8 @@ const (
 )
 
 var (
-	verbose bool
+	verbose      bool
+	preserveTest bool
 )
 
 func init() {
@@ -32,6 +33,7 @@ func init() {
 		flag.PrintDefaults()
 	}
 	flag.BoolVar(&verbose, "verbose", false, "shows all warnings")
+	flag.BoolVar(&preserveTest, "test", false, "preserve _test.go files in vendor'd projects")
 }
 
 func validateArgs() {


### PR DESCRIPTION
In certain cases, it might be desireable to preserve the tests of a
given vendor. Add a flag to make this possible.

Signed-off-by: Aleksa Sarai <asarai@suse.de>