### PR TITLE
clean: switch -test to a regex -whitelist flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,15 @@
 [![Build Status](https://travis-ci.org/LK4D4/vndr.svg?branch=master)](https://travis-ci.org/LK4D4/vndr)
 
 Vndr is simple vendoring tool, which is inspired by Docker vendor script.
-Vndr has only one option: `-verbose`.
+Vndr has only two options: `-verbose` and `-whitelist`, both of which do
+exactly what they say on the tin.
+
+* `-verbose` adds additional output, helpful for debugging issues.
+* `-whitelist` allows you to specify several regular expressions for paths
+  which will *not* be cleaned in the final stage of vendoring -- this is useful
+  for running tests in a vendored project or otherwise ensuring that some
+  important files are retained after `vndr` is done cleaning unused files from
+  your `vendor/` directory.
 
 ## vendor.conf
 
@@ -20,7 +28,7 @@ This config format is also accepted by [trash](https://github.com/rancher/trash)
 ## Initialization
 
 You can initiate your project with vendor directory and `vendor.conf` using command
-`vndr init`. This will populate your vendor directory with latest versions of 
+`vndr init`. This will populate your vendor directory with latest versions of
 all dependecies and also write `vendor.conf` config which you can use for changing
 versions later.
 

--- a/clean.go
+++ b/clean.go
@@ -72,14 +72,14 @@ func cleanVendor(vendorDir string, realDeps []*build.Package) error {
 			return nil
 		}
 
-		// When preserving tests don't delete testdata, let alone _test.go files.
-		if preserveTest {
-			if i.Name() == "testdata" {
-				return nil
-			}
-			if strings.HasSuffix(path, "_test.go") {
-				return nil
-			}
+		// Make sure we don't delete anything that matches the whitelist. The
+		// whitelist is relative to the vendor directory.
+		relPath, err := filepath.Rel(vendorDir, path)
+		if err != nil {
+			return err
+		}
+		if cleanWhitelist.matchString(relPath) {
+			return nil
 		}
 
 		if strings.HasPrefix(i.Name(), ".") || strings.HasPrefix(i.Name(), "_") {


### PR DESCRIPTION
-test was _far_ too single-purpose and also unweildy in certain cases
(it ignored "testdata" but not "fixtures" or similar). Instead of
special casing everything, just add a whitelist flag that people can use
for their own project requirements.

Replacement for #23.
Signed-off-by: Aleksa Sarai <asarai@suse.de>