### PR TITLE
clean.go: don't treat Go files as license files (e.g. "license_test.go")

### DIFF
--- a/clean.go
+++ b/clean.go
@@ -57,6 +57,10 @@ func isGoFile(path string) bool {
 // licenseFilesRegexp is a regexp of file names that are likely to contain licensing information
 var licenseFilesRegexp = regexp.MustCompile(`(?i).*(LICENSE|COPYING|PATENT|NOTICE|README).*`)
 
+func isLicenseFile(path string) bool {
+	return licenseFilesRegexp.MatchString(path) && !isGoFile(path)
+}
+
 // cleanVendor removes files from unused packages and non-go files
 func cleanVendor(vendorDir string, realDeps []*build.Package) error {
 	realPaths := make(map[string]bool)
@@ -100,7 +104,7 @@ func cleanVendor(vendorDir string, realDeps []*build.Package) error {
 		}
 
 		// keep files for licenses
-		if licenseFilesRegexp.MatchString(i.Name()) {
+		if isLicenseFile(i.Name()) {
 			return nil
 		}
 		// remove files from non-deps, non-go files and test files
@@ -123,7 +127,7 @@ func cleanVendor(vendorDir string, realDeps []*build.Package) error {
 		// remove licenses if it's only files
 		var onlyLicenses = true
 		for _, fi := range lst {
-			if !licenseFilesRegexp.MatchString(fi.Name()) {
+			if !isLicenseFile(fi.Name()) {
 				onlyLicenses = false
 				break
 			}

--- a/clean_test.go
+++ b/clean_test.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestLicenseFilesRegexp(t *testing.T) {
+	cases := map[string]bool{
+		"LICENSE":         true,
+		"LICENSE.code":    true,
+		"License.txt":     true,
+		"license.go":      false,
+		"license_test.go": false,
+		"foo_license.go":  false,
+		"license.c":       false,
+	}
+	for s, expected := range cases {
+		result := isLicenseFile(s)
+		if result != expected {
+			t.Fatalf("isLicenseFile(%q): expected %v, got %v", s, expected, result)
+		}
+	}
+}


### PR DESCRIPTION
ref: https://github.com/docker/docker/pull/31566#discussion_r104391574

cc @thaJeztah

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>