### PR TITLE
skip some tests on `go test -short`

### DIFF
--- a/test/vndr_test.go
+++ b/test/vndr_test.go
@@ -23,7 +23,14 @@ func setGopath(cmd *exec.Cmd, gopath string) {
 	cmd.Env = append(cmd.Env, "GOPATH="+gopath)
 }
 
+func skipOnShort(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+}
+
 func TestVndr(t *testing.T) {
+	skipOnShort(t)
 	vndrBin, err := exec.LookPath("vndr")
 	if err != nil {
 		t.Fatal(err)
@@ -81,6 +88,7 @@ func TestVndr(t *testing.T) {
 }
 
 func TestVndrInit(t *testing.T) {
+	skipOnShort(t)
 	vndrBin, err := exec.LookPath("vndr")
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Locally TestVndr took 36s, TestVndrInit took 11s.
This PR skips running these tests on `go test -short`.

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>