### PR TITLE
new flag: `-strict`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ exactly what they say on the tin.
   for running tests in a vendored project or otherwise ensuring that some
   important files are retained after `vndr` is done cleaning unused files from
   your `vendor/` directory.
+* `-strict` exists with non-zero status on non-trivial warning
   
 ## Installation
 

--- a/pkg.go
+++ b/pkg.go
@@ -65,12 +65,12 @@ func collectAllDeps(wd string, dlFunc func(imp string) (*build.Package, error), 
 				if dlFunc != nil {
 					ipkg, err = dlFunc(imp)
 				} else {
-					log.Printf("\tWARNING, dependency is not vendored: %s", imp)
+					Warnf("dependency is not vendored: %s", imp)
 				}
 			}
 			if _, ok := err.(*build.MultiplePackageError); !ok && err != nil {
 				if verbose {
-					log.Printf("\tWARNING %s: %v", imp, err)
+					log.Printf("\tWARNING(verbose) %s: %v", imp, err)
 				}
 				continue
 			}

--- a/warn.go
+++ b/warn.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"sync"
+)
+
+type warningCollector struct {
+	mu       sync.Mutex
+	warnings []string
+}
+
+func (w *warningCollector) warn(s string) {
+	w.mu.Lock()
+	w.warnings = append(w.warnings, s)
+	w.mu.Unlock()
+	log.Printf("WARNING: %s", s)
+}
+
+func (w *warningCollector) Warnf(format string, a ...interface{}) {
+	w.warn(fmt.Sprintf(format, a...))
+}
+
+func (w *warningCollector) Warn(a ...interface{}) {
+	w.warn(fmt.Sprint(a...))
+}
+
+func (w *warningCollector) Warns() []string {
+	var l []string
+	w.mu.Lock()
+	for _, s := range w.warnings {
+		l = append(l, s)
+	}
+	w.mu.Unlock()
+	return l
+}
+
+// WarningCollector is the default warning collector
+var WarningCollector = &warningCollector{}
+
+// Warnf logs a warning
+func Warnf(format string, a ...interface{}) {
+	WarningCollector.Warnf(format, a...)
+}
+
+// Warn logs a warning
+func Warn(a ...interface{}) {
+	WarningCollector.Warn(a...)
+}
+
+// Warns returns the logged warnings
+func Warns() []string {
+	return WarningCollector.Warns()
+}


### PR DESCRIPTION
This flag treats non-trivial warning as an error.

As discussed on Slack, this would be useful for detecting invalid vendoring on CI.

cc @moby/moby-maintainers

TODO: add more warnings (in separate PRs)

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>