### PR TITLE
able to ignore vendored files certain build tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Vndr has next command line arguments:
   important files are retained after `vndr` is done cleaning unused files from
   your `vendor/` directory.
 * `-strict` exits with non-zero status on non-trivial warning
-  
+
 ## Installation
 
 Execute

--- a/pkg.go
+++ b/pkg.go
@@ -13,6 +13,7 @@ import (
 var (
 	ctx = &build.Context{
 		UseAllFiles: true,
+		IgnoreTags:  []string{"ignore"},
 		Compiler:    runtime.Compiler,
 		CgoEnabled:  true,
 		GOROOT:      runtime.GOROOT(),


### PR DESCRIPTION
Some go packages includes files with certain build tags that is only
relevant for code generation and can usually be ignored when vendoring.
An example of such build tag is `+build ignore` as stated in go/build
doc:

```
To keep a file from being considered for the build:
// +build ignore
(any other unsatisfied word will work as well, but “ignore” is conventional.)
```

This patch add `-ignore-tags` flag which can be set as a list of tags to
be ignored when vendoring. This defaults to `[]string{"ignore"}`.

`IgnoreTags` will be processed before `UseAllFiles`, hence files
matching `IgnoreTags` will be matched even with `UseAllFiles` are set.
We also pruned such all IgnoredGoFiles as well.