### PR TITLE
Keep "go.mod" for reference

### DIFF
--- a/clean.go
+++ b/clean.go
@@ -62,7 +62,12 @@ func isLicenseFile(path string) bool {
 }
 
 func isVendorConfFile(path string) bool {
-	return filepath.Base(path) == "vendor.conf"
+	switch filepath.Base(path) {
+	case "go.mod", "vendor.conf":
+		return true
+	default:
+		return false
+	}
 }
 
 // cleanVendor removes files from unused packages and non-go files


### PR DESCRIPTION
Related to #5 this allows a human (or maybe a tool) to see if what
is being vendored by the top-level project is consistent with what the
vendored projects themselves are vendoring.
