### PR TITLE
support `github.com/coreos/go-systemd/v22`

### DIFF
--- a/godl/vcs.go
+++ b/godl/vcs.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 
 	"github.com/LK4D4/vndr/godl/singleflight"
+	"github.com/LK4D4/vndr/versioned"
 )
 
 // envForDir returns a copy of the environment
@@ -512,6 +513,9 @@ func repoRootFromVCSPaths(importPath, scheme string, security securityMode, vcsP
 			repo: match["repo"],
 			root: match["root"],
 		}
+		if versioned.IsVersioned(importPath) {
+			rr.root = importPath
+		}
 		return rr, nil
 	}
 	return nil, errUnknownSite
@@ -580,6 +584,9 @@ func repoRootForImportDynamic(importPath string, security securityMode) (*repoRo
 	}
 	if rr.vcs == nil {
 		return nil, fmt.Errorf("%s: unknown vcs %q", urlStr, mmi.VCS)
+	}
+	if versioned.IsVersioned(importPath) {
+		rr.root = importPath
 	}
 	return rr, nil
 }

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/LK4D4/vndr/build"
 	"github.com/LK4D4/vndr/godl"
+	"github.com/LK4D4/vndr/versioned"
 )
 
 const (
@@ -155,7 +156,7 @@ func validateDeps(deps []depEntry) error {
 		rootDeps := roots[r]
 		if len(rootDeps) == 1 {
 			d := rootDeps[0]
-			if d.importPath != r {
+			if d.importPath != r && !versioned.IsVersioned(d.importPath) {
 				Warnf("package %s is not root import, should be %s", d.importPath, r)
 				invalid = true
 				newDeps = append(newDeps, depEntry{importPath: r, rev: d.rev, repoPath: d.repoPath})

--- a/versioned/versioned.go
+++ b/versioned/versioned.go
@@ -1,0 +1,12 @@
+package versioned
+
+import (
+	"regexp"
+)
+
+var re = regexp.MustCompile(`/v[0-9]+$`)
+
+// IsVersioned true for string like "github.com/coreos/go-systemd/v22"
+func IsVersioned(s string) bool {
+	return re.MatchString(s)
+}


### PR DESCRIPTION
Support vendoring [`github.com/coreos/go-systemd/v22`](https://github.com/coreos/go-systemd/blob/v22.0.0/go.mod#L1) as follows:

`foo.go`:
```go
package foo

import (
        "github.com/coreos/go-systemd/v22/dbus"
)

func Foo() (*dbus.Conn, error) {
        return dbus.New()
}
```

`vendor.conf`:
```
github.com/coreos/go-systemd/v22 v22.0.0
github.com/godbus/dbus/v5 v5.0.3
```

Now `vndr` checks out the contents of `github.com/coreos/go-systemd@v22.0.0` repo
into the `./vendor/github.com/coreos/go-systemd/v22` directory.

Note that `vndr` does not verify the actual version number written in `go.mod`.
So `vndr github.com/coreos/go-systemd/v23 v22.0.0` would vendor v22, not v23.

Fix https://github.com/containerd/cgroups/issues/139
