### PR TITLE
respect --whitelist options when doing a full vendor cycle

### DIFF
--- a/main.go
+++ b/main.go
@@ -277,8 +277,17 @@ func main() {
 			cfgDeps = []depEntry{flagDep}
 		} else {
 			log.Println("Starting whole vndr cycle because no package specified")
-			if err := os.RemoveAll(vd); err != nil {
-				log.Fatal(err)
+			if len(cleanWhitelist) > 0 {
+				for _, regex := range cleanWhitelist {
+					log.Printf("\tIgnoring paths matching %q", regex.String())
+				}
+				if err := cleanVendor(vd, nil); err != nil {
+					log.Fatal(err)
+				}
+			} else {
+				if err := os.RemoveAll(vd); err != nil {
+					log.Fatal(err)
+				}
 			}
 		}
 		startDownload := time.Now()


### PR DESCRIPTION
partially addresses https://github.com/LK4D4/vndr/issues/72

Commit b1caa0025ab0717d0d75c395dbc25825b739d48c (https://github.com/LK4D4/vndr/pull/24) added a `--whitelist` flag to allow ignoring paths in the vendor directory when cleaning up unused packages/files.

However, 4b11a0f89b18b2d4360f4b725fb5045308522a98 (https://github.com/LK4D4/vndr/pull/65) added an optimization to clean the whole vendor directory when doing a full vendor cycle. Unfortunately, that change did not take the `--whitelist` option into account, resulting in whitelisted packages/files to be deleted when doing a full vendor cycle.

This patch checks if a whitelist option is set when doing a full vendor cycle, and if so, ignores the specified paths when cleaning.

Using the "v18.06.0-ce" branch on github.com/docker/engine, which has a custom `archive/tar` package in the vendor directory;

    $ git checkout v18.06.0-ce
    $ vndr --whitelist 'archive/tar/.*'
    2020/01/20 18:50:51 Collecting initial packages
    2020/01/20 18:50:52 Download dependencies
    2020/01/20 18:50:55 Starting whole vndr cycle because no package specified
    2020/01/20 18:50:55 Ignoring paths matching "archive/tar/.*"
    ...
    020/01/20 18:53:46  Finished clone github.com/aws/aws-sdk-go
    2020/01/20 18:53:46 Finished clone github.com/hashicorp/consul
    2020/01/20 18:53:46 Dependencies downloaded. Download time: 2m50.469326342s
    2020/01/20 18:53:46 Collecting all dependencies
    2020/01/20 18:53:57 Clean vendor dir from unused packages
    2020/01/20 18:53:57 Ignoring paths matching "archive/tar/.*"
    2020/01/20 18:53:59 Success
    2020/01/20 18:53:59 Running time: 3m7.731082301s

After vendoring completed, verify that the `archive/tar` directory was kept:

    ls vendor/archive/tar
    LICENSE         README.md       common.go       format.go       reader.go       stat_actime1.go stat_actime2.go stat_unix.go    strconv.go      writer.go
