### PR TITLE
Fix versioned dependencies being removed during clone

### DIFF
--- a/clone.go
+++ b/clone.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -55,6 +56,11 @@ func parseDeps(r io.Reader) ([]depEntry, error) {
 }
 
 func cloneAll(vd string, ds []depEntry) error {
+	// Sort dependencies so that longest import paths are handled last. This
+	// prevents, e.g. "github.com/foo/bar" from deleting "github.com/foo/bar/v3"
+	sort.Slice(ds, func(i, j int) bool {
+		return len(ds[i].importPath) < len(ds[j].importPath)
+	})
 	var wg sync.WaitGroup
 	errCh := make(chan error, len(ds))
 	limit := make(chan struct{}, 16)


### PR DESCRIPTION
If both a "versioned" and "non-versioned" version of a dependency
exists in vendor.conf, the "longest" path should be cloned last,
otherwise the versioned dependency may be deleted when cloning its
non-versioned variant.

For example, with the following vendor.conf:

    github.com/coreos/go-systemd/v22 v22.0.0
    github.com/coreos/go-systemd     v17

Running vndr would;

1. recursively delete "vendor/src/github.com/coreos/go-systemd/v22:
2. start cloning "github.com/coreos/go-systemd/v22"
3. recursively delete "vendor/src/github.com/coreos/go-systemd"
4. start cloning "github.com/coreos/go-systemd"

This would lead to a conflicting situation; step 3. will remove
the dependency that was previously cloned (or in the process
of being cloned).

This patch sorts the dependencies by import-path, cloning the
shortest import paths first, which should prevent the race condition.
