### PR TITLE
cleanVCS: prevent panic

### DIFF
--- a/clean.go
+++ b/clean.go
@@ -172,6 +172,9 @@ func cleanVCS(v *godl.VCS) error {
 		return err
 	}
 	return filepath.Walk(v.Root, func(path string, i os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
 		if path == vendorDir {
 			return nil
 		}


### PR DESCRIPTION
If an error occurs during the filepath.Walk, fileInfo may be nil and cause
a panic;

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x55eb5c97b20c]

goroutine 185 [running]:
main.cleanVCS.func1(0xc00011c6c0, 0x8d, 0x0, 0x0, 0x55eb5cb63260, 0xc0004b2db0, 0x0, 0x0)
    /tmp/tmp.kcK80TojkZ/src/github.com/LK4D4/vndr/clean.go:178 +0x4c
path/filepath.walk(0xc0000473e0, 0x5a, 0x55eb5cb6b900, 0xc000658c30, 0x55eb5cb598b8, 0x0, 0x0)
    /usr/local/go/src/path/filepath/path.go:378 +0x20e
path/filepath.walk(0xc000075920, 0x55, 0x55eb5cb6b900, 0xc000185790, 0x55eb5cb598b8, 0x0, 0x0)
    /usr/local/go/src/path/filepath/path.go:382 +0x301
path/filepath.walk(0xc0007a0780, 0x4d, 0x55eb5cb6b900, 0xc0002d1e10, 0x55eb5cb598b8, 0x0, 0x0)
    /usr/local/go/src/path/filepath/path.go:382 +0x301
path/filepath.walk(0xc0007a0690, 0x48, 0x55eb5cb6b900, 0xc0002d1d40, 0x55eb5cb598b8, 0x0, 0x0)
    /usr/local/go/src/path/filepath/path.go:382 +0x301
path/filepath.walk(0xc000488000, 0x44, 0x55eb5cb6b900, 0xc00023fa00, 0x55eb5cb598b8, 0x0, 0xc0000ae100)
    /usr/local/go/src/path/filepath/path.go:382 +0x301
path/filepath.Walk(0xc000488000, 0x44, 0x55eb5cb598b8, 0x0, 0x49)
    /usr/local/go/src/path/filepath/path.go:404 +0x101
main.cleanVCS(0xc000453680, 0x1c, 0x0)
    /tmp/tmp.kcK80TojkZ/src/github.com/LK4D4/vndr/clean.go:174 +0x114
main.cloneDep(0xc000098540, 0x27, 0xc00001d420, 0x1c, 0xc00001d454, 0x28, 0x0, 0x0, 0x0, 0x0)
    /tmp/tmp.kcK80TojkZ/src/github.com/LK4D4/vndr/clone.go:106 +0x188
main.cloneAll.func1(0xc0007fe600, 0xc000098540, 0x27, 0xc00041a3c0, 0xc00056ce80, 0xc00001d420, 0x1c, 0xc00001d454, 0x28, 0x0, ...)
    /tmp/tmp.kcK80TojkZ/src/github.com/LK4D4/vndr/clone.go:72 +0x2be
created by main.cloneAll
    /tmp/tmp.kcK80TojkZ/src/github.com/LK4D4/vndr/clone.go:63 +0x1c7
```

