### PR TITLE
Consider '.syso' as a Go file when cleaning

### DIFF
--- a/clean.go
+++ b/clean.go
@@ -51,7 +51,7 @@ func isInterestingDir(path string) bool {
 
 func isGoFile(path string) bool {
 	ext := filepath.Ext(path)
-	return ext == ".go" || ext == ".c" || ext == ".h" || ext == ".s" || ext == ".proto"
+	return ext == ".go" || ext == ".c" || ext == ".h" || ext == ".s" || ext == ".proto" || ext == ".syso"
 }
 
 // licenseFilesRegexp is a regexp of file names that are likely to contain licensing information


### PR DESCRIPTION
This fixes an issue where importing a package in order to bundle a .syso doesn't work, because vndr deletes the .syso file when cleaning.

As an example, see https://github.com/containerd/containerd/pull/4427#discussion_r461738949 and https://github.com/containerd/containerd/commit/134e82505b78fc7a560d6ee7bd818c9d3dfd5e5f.

In short, I expect to be able to
```
import _ "github.com/Microsoft/hcsshim/test/functional/manifest"
```
and have [`rsrc_amd64.syso`](https://github.com/microsoft/hcsshim/blob/master/test/functional/manifest/) included in the build, but without this fix, `vndr` leaves only the manifest.go.