### PR TITLE
godl: only use git:// scheme as last option

### DIFF
--- a/godl/vcs.go
+++ b/godl/vcs.go
@@ -120,7 +120,7 @@ var vcsGit = &vcsCmd{
 	createCmd:    []string{"clone {repo} {dir}", "-C {dir} submodule update --init --recursive"},
 	createRevCmd: []string{"clone {repo} {dir}", "-C {dir} submodule update --init --recursive", "-C {dir} checkout {rev}", "-C {dir} reset --hard {rev}"},
 
-	scheme:     []string{"git", "https", "http", "git+ssh", "ssh"},
+	scheme:     []string{"https", "http", "git+ssh", "ssh", "git"},
 	pingCmd:    "ls-remote {scheme}://{repo}",
 	remoteRepo: gitRemoteRepo,
 }


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/3405#issuecomment-1010482183
- relates to https://github.com/docker/cli/pull/3514#issuecomment-1084353541

The `git://` protocol is insecure (equivalent of `http://`), and GitHub has
deprecated support for this, see:
https://github.blog/2021-09-01-improving-git-protocol-security-github/

Which causes vendoring with `vndr` to fail:

    2022/03/31 09:29:01 Download dependencies
    2022/03/31 09:29:02 Starting whole vndr cycle because no package specified
    fatal: remote error:
      The unauthenticated git protocol on port 9418 is no longer supported.
    Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
    fatal: remote error:
      The unauthenticated git protocol on port 9418 is no longer supported.
    Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
    fatal: remote error:
      The unauthenticated git protocol on port 9418 is no longer supported.
    Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
    fatal: remote error:
      The unauthenticated git protocol on port 9418 is no longer supported.
    Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
    fatal: remote error:
      The unauthenticated git protocol on port 9418 is no longer supported.
    Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
    fatal: remote error:
      The unauthenticated git protocol on port 9418 is no longer supported.
    Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.

This patch moves the `git://` scheme to the end of the list of schemes to try,
so that `https://` is used as default. I kept `git://` in the list, to allow
it to be used for servers (other than GitHub) that still support it.

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>