### PR TITLE
Migrate to Go modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/LK4D4/vndr
+
+go 1.22.3


### PR DESCRIPTION
This switches to [Go modules](https://go.dev/blog/using-go-modules), which have now been the standard for dependency management in Go codebases for a while.